### PR TITLE
fix(client): generate unique aircraft ids and isolate session logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,9 @@ Supported arguments:
 - The server appends completed flights to `output/stats/flight_stats.csv`.
 - Logs are written to `output/logs/` and mirrored to the console.
 - For distributed performance testing, update client IP settings to the actual server machine address.
+
+
+## Client identity and log files
+- Each client process now receives a unique aircraft ID at startup unless `--aircraft-id` is explicitly provided.
+- Each client session writes to its own log file in `output/logs/`, with the filename including the aircraft ID, process ID, and session timestamp.
+- Load, spike, and endurance batch scripts now pass unique `--aircraft-id` values so concurrent test runs remain analytically valid.

--- a/scripts/endurance-test.bat
+++ b/scripts/endurance-test.bat
@@ -1,10 +1,10 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 pushd %~dp0..\
 
-set EXE=x64\Release\ClientApp.exe
-if not exist %EXE% set EXE=x64\Debug\ClientApp.exe
-if not exist %EXE% (
+set "EXE=x64\Release\ClientApp.exe"
+if not exist "%EXE%" set "EXE=x64\Debug\ClientApp.exe"
+if not exist "%EXE%" (
   echo Build ClientApp first.
   popd
   exit /b 1
@@ -12,15 +12,17 @@ if not exist %EXE% (
 
 set /A count=100
 set /A delaySeconds=250
+set /A wave=1
 
 :loop
 set /A index=1
 :spawn
-if %index% leq %count% (
-  start "Endurance-%index%" /min %EXE%
-  set /A index=%index%+1
+if !index! leq %count% (
+  start "Endurance-!wave!-!index!" /min "%EXE%" --aircraft-id AIR-END-!wave!-!index!
+  set /A index=!index!+1
   goto :spawn
 )
 
+set /A wave=!wave!+1
 timeout /t %delaySeconds% > NUL
 goto :loop

--- a/scripts/load-test.bat
+++ b/scripts/load-test.bat
@@ -1,10 +1,10 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 pushd %~dp0..\
 
-set EXE=x64\Release\ClientApp.exe
-if not exist %EXE% set EXE=x64\Debug\ClientApp.exe
-if not exist %EXE% (
+set "EXE=x64\Release\ClientApp.exe"
+if not exist "%EXE%" set "EXE=x64\Debug\ClientApp.exe"
+if not exist "%EXE%" (
   echo Build ClientApp first.
   popd
   exit /b 1
@@ -14,9 +14,9 @@ set /A index=1
 set /A count=25
 
 :while
-if %index% leq %count% (
-  start "Client-%index%" /min %EXE%
-  set /A index=%index%+1
+if !index! leq %count% (
+  start "Client-!index!" /min "%EXE%" --aircraft-id AIR-LT-!index!
+  set /A index=!index!+1
   goto :while
 )
 

--- a/scripts/run-client.bat
+++ b/scripts/run-client.bat
@@ -2,14 +2,14 @@
 setlocal
 pushd %~dp0..\
 
-set EXE=x64\Debug\ClientApp.exe
-if not exist %EXE% set EXE=x64\Release\ClientApp.exe
-if not exist %EXE% (
+set "EXE=x64\Debug\ClientApp.exe"
+if not exist "%EXE%" set "EXE=x64\Release\ClientApp.exe"
+if not exist "%EXE%" (
   echo Build the solution first from Visual Studio.
   popd
   exit /b 1
 )
 
-start "ClientApp" %EXE%
+start "ClientApp" "%EXE%" %*
 popd
 endlocal

--- a/scripts/run-server.bat
+++ b/scripts/run-server.bat
@@ -2,14 +2,14 @@
 setlocal
 pushd %~dp0..\
 
-set EXE=x64\Debug\ServerApp.exe
-if not exist %EXE% set EXE=x64\Release\ServerApp.exe
-if not exist %EXE% (
+set "EXE=x64\Debug\ServerApp.exe"
+if not exist "%EXE%" set "EXE=x64\Release\ServerApp.exe"
+if not exist "%EXE%" (
   echo Build the solution first from Visual Studio.
   popd
   exit /b 1
 )
 
-start "ServerApp" %EXE%
+start "ServerApp" "%EXE%" %*
 popd
 endlocal

--- a/scripts/spike-test.bat
+++ b/scripts/spike-test.bat
@@ -1,10 +1,10 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 pushd %~dp0..\
 
-set EXE=x64\Release\ClientApp.exe
-if not exist %EXE% set EXE=x64\Debug\ClientApp.exe
-if not exist %EXE% (
+set "EXE=x64\Release\ClientApp.exe"
+if not exist "%EXE%" set "EXE=x64\Debug\ClientApp.exe"
+if not exist "%EXE%" (
   echo Build ClientApp first.
   popd
   exit /b 1
@@ -14,9 +14,9 @@ set /A index=1
 set /A count=100
 
 :while
-if %index% leq %count% (
-  start "Spike-%index%" /min %EXE%
-  set /A index=%index%+1
+if !index! leq %count% (
+  start "Spike-!index!" /min "%EXE%" --aircraft-id AIR-SPIKE-!index!
+  set /A index=!index!+1
   goto :while
 )
 

--- a/src/client/ClientApp.cpp
+++ b/src/client/ClientApp.cpp
@@ -8,10 +8,16 @@
 #include "../shared/Common.h"
 #include <thread>
 #include <string>
-#include <cstdlib>
-#include <ctime>
 #include <sstream>
 #include <vector>
+#include <chrono>
+#include <cctype>
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
 
 namespace FleetTelemetry
 {
@@ -24,6 +30,7 @@ namespace FleetTelemetry
             std::string TelemetryFile;
             std::string AircraftId;
             int SendIntervalMs = 0;
+            bool AircraftIdProvidedByUser = false;
         };
 
         std::string MakeSafeFileToken(std::string value)
@@ -38,14 +45,39 @@ namespace FleetTelemetry
             return value;
         }
 
-        std::string GenerateAircraftId(const std::string& prefix)
+        unsigned long GetProcessIdValue()
         {
-            std::srand(static_cast<unsigned int>(std::time(nullptr)) ^ static_cast<unsigned int>(std::clock()));
-            const int randomValue = std::rand() % 100000;
+#ifdef _WIN32
+            return static_cast<unsigned long>(::GetCurrentProcessId());
+#else
+            return static_cast<unsigned long>(::getpid());
+#endif
+        }
+
+        long long GetSessionTimestampMs()
+        {
+            return static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count());
+        }
+
+        std::string BuildUniqueAircraftId(const std::string& prefix)
+        {
+            const std::string normalizedPrefix = MakeSafeFileToken(prefix.empty() ? "AIR" : prefix);
             std::ostringstream stream;
-            stream << (prefix.empty() ? "AIR" : prefix)
-                   << "-" << static_cast<long long>(std::time(nullptr))
-                   << "-" << randomValue;
+            stream << normalizedPrefix
+                   << "-PID" << GetProcessIdValue()
+                   << "-T" << GetSessionTimestampMs();
+            return stream.str();
+        }
+
+        std::string BuildClientLogPath(const std::string& aircraftId)
+        {
+            std::ostringstream stream;
+            stream << "output/logs/client_"
+                   << MakeSafeFileToken(aircraftId)
+                   << "_pid" << GetProcessIdValue()
+                   << "_session" << GetSessionTimestampMs()
+                   << ".log";
             return stream.str();
         }
 
@@ -56,7 +88,8 @@ namespace FleetTelemetry
             options.ServerPort = config.ServerPort;
             options.TelemetryFile = config.TelemetryFile;
             options.SendIntervalMs = config.SendIntervalMs;
-            options.AircraftId = config.ClientName;
+
+            std::string aircraftIdPrefix = config.ClientName;
 
             for (int index = 1; index < argc; ++index)
             {
@@ -87,6 +120,7 @@ namespace FleetTelemetry
                 else if (argument == "--aircraft-id")
                 {
                     readValue(options.AircraftId);
+                    options.AircraftIdProvidedByUser = !options.AircraftId.empty();
                 }
                 else if (argument == "--send-interval-ms")
                 {
@@ -102,13 +136,13 @@ namespace FleetTelemetry
                 options.TelemetryFile = "data/sample/telemetry_1.txt";
             }
 
-            if (options.AircraftId.empty())
+            if (!options.AircraftIdProvidedByUser)
             {
-                options.AircraftId = GenerateAircraftId("AIR");
-            }
-            else if (options.AircraftId.find("Client-") == 0 || options.AircraftId.find("Client") == 0)
-            {
-                options.AircraftId = GenerateAircraftId(options.AircraftId);
+                if (aircraftIdPrefix.empty())
+                {
+                    aircraftIdPrefix = "AIR";
+                }
+                options.AircraftId = BuildUniqueAircraftId(aircraftIdPrefix);
             }
 
             if (options.SendIntervalMs < 0)
@@ -125,11 +159,12 @@ namespace FleetTelemetry
         const auto config = Config::LoadClientConfig("config/client.config.json");
         const RuntimeOptions options = ResolveRuntimeOptions(config, argc, argv);
 
-        Logger logger("output/logs/client_" + MakeSafeFileToken(options.AircraftId) + ".log");
+        Logger logger(BuildClientLogPath(options.AircraftId));
         logger.Info("Client starting");
         logger.Info("Aircraft ID: " + options.AircraftId);
         logger.Info("Telemetry file: " + options.TelemetryFile);
         logger.Info("Server endpoint: " + options.ServerIp + ":" + std::to_string(options.ServerPort));
+        logger.Info(std::string("Aircraft ID source: ") + (options.AircraftIdProvidedByUser ? "command line" : "generated at startup"));
 
         TelemetryReader reader;
         if (!reader.Open(options.TelemetryFile))


### PR DESCRIPTION
## Summary
- generate a unique aircraft ID per client session
- isolate client logs so each process writes to its own file
- rerun multiclient validation with new output

## Why
The project requires each client to have a unique ID and the server to identify aircraft by transmitted ID. Shared IDs and shared logs made parallel-run validation unreliable.

## Validation
- ran server with multiple sequential/parallel client launches
- verified distinct AIR-PID... ids in client logs
- verified per-session client log files
- verified server processed and completed flights
- verified stats CSV rows generated for distinct aircraft ids

## Remaining follow-up
- clean disconnect handling to reduce normal-run WSA 10054 entries
- formalize clean-run test procedure
- collect performance-test evidence artifacts