### PR TITLE
-implement multi-client telemetry replay with random file selection a…

### DIFF
--- a/src/client/ClientApp.cpp
+++ b/src/client/ClientApp.cpp
@@ -6,18 +6,19 @@
 #include "../shared/Config.h"
 #include "../shared/Logger.h"
 #include "../shared/Common.h"
+
 #include <thread>
 #include <string>
 #include <sstream>
 #include <vector>
 #include <chrono>
 #include <cctype>
-
-#ifdef _WIN32
-#include <Windows.h>
-#else
-#include <unistd.h>
-#endif
+#include <random>
+#include <atomic>
+#include <filesystem>
+#include <iostream>
+#include <iomanip>
+#include <mutex>
 
 namespace FleetTelemetry
 {
@@ -33,52 +34,70 @@ namespace FleetTelemetry
             bool AircraftIdProvidedByUser = false;
         };
 
-        std::string MakeSafeFileToken(std::string value)
+        std::atomic<int> g_aircraftSequence{ 0 };
+        std::mutex g_consoleMutex;
+
+        std::string BuildReadableAircraftId()
         {
-            for (char& ch : value)
+            const int id = ++g_aircraftSequence;
+
+            std::ostringstream stream;
+            stream << "AIRCRAFT-" << std::setw(3) << std::setfill('0') << id;
+            return stream.str();
+        }
+
+#include <filesystem>
+#include <vector>
+#include <string>
+
+        std::vector<std::string> FindTelemetryFiles(const std::string& directoryPath)
+        {
+            std::vector<std::string> files;
+            namespace fs = std::filesystem;
+
+            try
             {
-                if (!(std::isalnum(static_cast<unsigned char>(ch)) || ch == '-' || ch == '_'))
+                if (!fs::exists(directoryPath) || !fs::is_directory(directoryPath))
                 {
-                    ch = '_';
+                    return files;
+                }
+
+                for (const auto& entry : fs::directory_iterator(directoryPath))
+                {
+                    if (!entry.is_regular_file())
+                    {
+                        continue;
+                    }
+
+                    const std::string extension = entry.path().extension().string();
+                    if (extension == ".txt" || extension == ".csv")
+                    {
+                        files.push_back(entry.path().string());
+                    }
                 }
             }
-            return value;
+            catch (...)
+            {
+                files.clear();
+            }
+
+            return files;
         }
 
-        unsigned long GetProcessIdValue()
+        std::string SelectRandomTelemetryFile()
         {
-#ifdef _WIN32
-            return static_cast<unsigned long>(::GetCurrentProcessId());
-#else
-            return static_cast<unsigned long>(::getpid());
-#endif
-        }
+            std::vector<std::string> files = FindTelemetryFiles("data/sample");
 
-        long long GetSessionTimestampMs()
-        {
-            return static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::system_clock::now().time_since_epoch()).count());
-        }
+            if (files.empty())
+            {
+                return "data/sample/telemetry_1.txt";
+            }
 
-        std::string BuildUniqueAircraftId(const std::string& prefix)
-        {
-            const std::string normalizedPrefix = MakeSafeFileToken(prefix.empty() ? "AIR" : prefix);
-            std::ostringstream stream;
-            stream << normalizedPrefix
-                   << "-PID" << GetProcessIdValue()
-                   << "-T" << GetSessionTimestampMs();
-            return stream.str();
-        }
-
-        std::string BuildClientLogPath(const std::string& aircraftId)
-        {
-            std::ostringstream stream;
-            stream << "output/logs/client_"
-                   << MakeSafeFileToken(aircraftId)
-                   << "_pid" << GetProcessIdValue()
-                   << "_session" << GetSessionTimestampMs()
-                   << ".log";
-            return stream.str();
+            static thread_local std::mt19937 gen(std::random_device{}());
+            std::uniform_int_distribution<std::size_t> dist(0, files.size() - 1);
+            std::cout << "Found " << files.size() << " telemetry files in data/sample\n";
+            
+            return files[dist(gen)];
         }
 
         RuntimeOptions ResolveRuntimeOptions(const ClientConfig& config, int argc, char* argv[])
@@ -89,18 +108,17 @@ namespace FleetTelemetry
             options.TelemetryFile = config.TelemetryFile;
             options.SendIntervalMs = config.SendIntervalMs;
 
-            std::string aircraftIdPrefix = config.ClientName;
-
             for (int index = 1; index < argc; ++index)
             {
                 const std::string argument = argv[index];
+
                 auto readValue = [&](std::string& target)
-                {
-                    if (index + 1 < argc)
                     {
-                        target = argv[++index];
-                    }
-                };
+                        if (index + 1 < argc)
+                        {
+                            target = argv[++index];
+                        }
+                    };
 
                 if (argument == "--server-ip")
                 {
@@ -131,18 +149,11 @@ namespace FleetTelemetry
                 }
             }
 
-            if (options.TelemetryFile.empty())
-            {
-                options.TelemetryFile = "data/sample/telemetry_1.txt";
-            }
+            options.TelemetryFile = SelectRandomTelemetryFile();
 
             if (!options.AircraftIdProvidedByUser)
             {
-                if (aircraftIdPrefix.empty())
-                {
-                    aircraftIdPrefix = "AIR";
-                }
-                options.AircraftId = BuildUniqueAircraftId(aircraftIdPrefix);
+                options.AircraftId = BuildReadableAircraftId();
             }
 
             if (options.SendIntervalMs < 0)
@@ -152,6 +163,40 @@ namespace FleetTelemetry
 
             return options;
         }
+
+        void PrintClientHeader(const RuntimeOptions& options)
+        {
+            std::lock_guard<std::mutex> lock(g_consoleMutex);
+            std::cout << "\n==================================================\n";
+            std::cout << "Client Started\n";
+            std::cout << "Airplane ID   : " << options.AircraftId << "\n";
+            std::cout << "Telemetry File: " << options.TelemetryFile << "\n";
+            std::cout << "==================================================\n";
+        }
+
+        void PrintParsedRecord(const TelemetryRecord& record)
+        {
+            std::lock_guard<std::mutex> lock(g_consoleMutex);
+            std::cout << "[" << record.AircraftId << "] "
+                << "Timestamp: " << record.Timestamp
+                << " | Fuel Quantity: " << record.FuelQuantity
+                << "\n";
+        }
+
+        void PrintClientFooter(const std::string& aircraftId,
+            int totalLines,
+            int sentRecords,
+            int skippedLines)
+        {
+            std::lock_guard<std::mutex> lock(g_consoleMutex);
+            std::cout << "--------------------------------------------------\n";
+            std::cout << "Client Finished: " << aircraftId << "\n";
+            std::cout << "Total input lines: " << totalLines << "\n";
+            std::cout << "Records parsed   : " << sentRecords << "\n";
+            std::cout << "Lines skipped    : " << skippedLines << "\n";
+            std::cout << "EOF reached. File closed. Client terminated.\n";
+            std::cout << "--------------------------------------------------\n";
+        }
     }
 
     int ClientApp::Run(int argc, char* argv[]) const
@@ -159,41 +204,53 @@ namespace FleetTelemetry
         const auto config = Config::LoadClientConfig("config/client.config.json");
         const RuntimeOptions options = ResolveRuntimeOptions(config, argc, argv);
 
-        Logger logger(BuildClientLogPath(options.AircraftId));
+        Logger logger("output/logs/" + options.AircraftId + ".log");
         logger.Info("Client starting");
         logger.Info("Aircraft ID: " + options.AircraftId);
         logger.Info("Telemetry file: " + options.TelemetryFile);
-        logger.Info("Server endpoint: " + options.ServerIp + ":" + std::to_string(options.ServerPort));
-        logger.Info(std::string("Aircraft ID source: ") + (options.AircraftIdProvidedByUser ? "command line" : "generated at startup"));
+
+        PrintClientHeader(options);
 
         TelemetryReader reader;
         if (!reader.Open(options.TelemetryFile))
         {
             logger.Error("Unable to open telemetry file");
+
+            std::lock_guard<std::mutex> lock(g_consoleMutex);
+            std::cout << "ERROR: Unable to open telemetry file: "
+                << options.TelemetryFile << "\n";
             return 1;
         }
 
         ClientSocket socket;
         std::string socketError;
-        logger.Info("Attempting server connection");
-        if (!socket.Connect(options.ServerIp, options.ServerPort, &socketError))
+        bool serverConnected = false;
+
+        if (socket.Connect(options.ServerIp, options.ServerPort, &socketError))
+        {
+            serverConnected = true;
+            logger.Info("Connection established");
+        }
+        else
         {
             logger.Error("Connection failed: " + socketError);
-            reader.Close();
-            return 1;
+            std::lock_guard<std::mutex> lock(g_consoleMutex);
+            std::cout << "NOTE: Server connection failed for "
+                << options.AircraftId
+                << ". Continuing in display-only mode.\n";
         }
-        logger.Info("Connection established");
 
         TelemetryParser parser;
         PacketBuilder builder;
         std::string line;
         int totalLines = 0;
-        int sentRecords = 0;
+        int parsedRecords = 0;
         int skippedLines = 0;
 
         while (reader.ReadNextLine(line))
         {
             ++totalLines;
+
             TelemetryRecord record;
             if (!parser.ParseLine(line, options.AircraftId, record))
             {
@@ -201,19 +258,22 @@ namespace FleetTelemetry
                 continue;
             }
 
-            const std::string packet = builder.Build(record);
-            if (!socket.SendLine(packet, &socketError))
-            {
-                logger.Error("Transmission interrupted: " + socketError);
-                socket.Disconnect();
-                reader.Close();
-                return 1;
-            }
+            ++parsedRecords;
+            PrintParsedRecord(record);
 
-            ++sentRecords;
-            if (sentRecords == 1 || sentRecords % 100 == 0)
+            if (serverConnected)
             {
-                logger.Info("Telemetry records transmitted: " + std::to_string(sentRecords));
+                const std::string packet = builder.Build(record);
+                if (!socket.SendLine(packet, &socketError))
+                {
+                    logger.Error("Transmission interrupted: " + socketError);
+                    std::lock_guard<std::mutex> lock(g_consoleMutex);
+                    std::cout << "WARNING: Send failed for "
+                        << options.AircraftId
+                        << ". Continuing local display only.\n";
+                    socket.Disconnect();
+                    serverConnected = false;
+                }
             }
 
             if (options.SendIntervalMs > 0)
@@ -223,12 +283,18 @@ namespace FleetTelemetry
         }
 
         reader.Close();
-        socket.Disconnect();
+
+        if (serverConnected)
+        {
+            socket.Disconnect();
+        }
 
         logger.Info("Client completed flight replay");
         logger.Info("Total input lines: " + std::to_string(totalLines));
-        logger.Info("Records sent: " + std::to_string(sentRecords));
+        logger.Info("Records parsed: " + std::to_string(parsedRecords));
         logger.Info("Lines skipped: " + std::to_string(skippedLines));
+
+        PrintClientFooter(options.AircraftId, totalLines, parsedRecords, skippedLines);
         return 0;
     }
 }

--- a/src/client/TelemetryParser.cpp
+++ b/src/client/TelemetryParser.cpp
@@ -1,7 +1,6 @@
 #include "TelemetryParser.h"
 #include "../shared/Common.h"
 #include <sstream>
-#include <cctype>
 
 namespace FleetTelemetry
 {
@@ -29,6 +28,7 @@ namespace FleetTelemetry
             {
                 return false;
             }
+
             workingLine = Trim(workingLine.substr(commaPosition + 1));
         }
 

--- a/src/client/TelemetryReader.cpp
+++ b/src/client/TelemetryReader.cpp
@@ -1,5 +1,4 @@
 #include "TelemetryReader.h"
-#include "TelemetryParser.h"
 
 namespace FleetTelemetry
 {
@@ -13,7 +12,9 @@ namespace FleetTelemetry
     bool TelemetryReader::ReadNextLine(std::string& outLine)
     {
         if (!m_input.is_open())
+        {
             return false;
+        }
 
         return static_cast<bool>(std::getline(m_input, outLine));
     }
@@ -21,38 +22,13 @@ namespace FleetTelemetry
     void TelemetryReader::Close()
     {
         if (m_input.is_open())
+        {
             m_input.close();
+        }
     }
 
     bool TelemetryReader::IsOpen() const
     {
         return m_input.is_open();
-    }
-
-    std::vector<TelemetryRecord> TelemetryReader::ReadAll(const std::string& filePath)
-    {
-        std::vector<TelemetryRecord> records;
-
-        if (!Open(filePath))
-        {
-            return records;
-        }
-
-        TelemetryParser parser;
-        std::string line;
-        const std::string aircraftId = "AIR-001";
-
-        while (ReadNextLine(line))
-        {
-            TelemetryRecord record;
-
-            if (parser.ParseLine(line, aircraftId, record))
-            {
-                records.push_back(record);
-            }
-        }
-
-        Close();
-        return records;
     }
 }

--- a/src/client/TelemetryReader.h
+++ b/src/client/TelemetryReader.h
@@ -15,8 +15,6 @@ namespace FleetTelemetry
         void Close();
         bool IsOpen() const;
 
-        std::vector<TelemetryRecord> ReadAll(const std::string& filePath);
-
     private:
         std::ifstream m_input;
     };

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -1,7 +1,142 @@
 #include "ClientApp.h"
 
+#include <thread>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+
+namespace
+{
+    struct LaunchOptions
+    {
+        int ClientCount = 3;
+        int AircraftStart = 1;
+        int AircraftEnd = 3;
+    };
+
+    int ParseIntOrDefault(const char* text, int defaultValue)
+    {
+        try
+        {
+            return std::stoi(text);
+        }
+        catch (...)
+        {
+            return defaultValue;
+        }
+    }
+
+    LaunchOptions GetLaunchOptions(int argc, char* argv[])
+    {
+        LaunchOptions options;
+
+        for (int index = 1; index < argc; ++index)
+        {
+            const std::string argument = argv[index];
+
+            if (argument == "--client-count" && index + 1 < argc)
+            {
+                options.ClientCount = ParseIntOrDefault(argv[++index], 3);
+            }
+            else if (argument == "--aircraft-start" && index + 1 < argc)
+            {
+                options.AircraftStart = ParseIntOrDefault(argv[++index], 1);
+            }
+            else if (argument == "--aircraft-end" && index + 1 < argc)
+            {
+                options.AircraftEnd = ParseIntOrDefault(argv[++index], 3);
+            }
+        }
+
+        if (options.ClientCount < 1)
+        {
+            options.ClientCount = 1;
+        }
+
+        if (options.AircraftStart < 1)
+        {
+            options.AircraftStart = 1;
+        }
+
+        if (options.AircraftEnd < options.AircraftStart)
+        {
+            options.AircraftEnd = options.AircraftStart;
+        }
+
+        const int availableIds = options.AircraftEnd - options.AircraftStart + 1;
+        if (options.ClientCount > availableIds)
+        {
+            options.ClientCount = availableIds;
+        }
+
+        return options;
+    }
+
+    std::string BuildAircraftId(int aircraftNumber)
+    {
+        std::ostringstream stream;
+        stream << "AIRCRAFT-";
+
+        if (aircraftNumber < 10)
+        {
+            stream << "00";
+        }
+        else if (aircraftNumber < 100)
+        {
+            stream << "0";
+        }
+
+        stream << aircraftNumber;
+        return stream.str();
+    }
+}
+
 int main(int argc, char* argv[])
 {
-    FleetTelemetry::ClientApp app;
-    return app.Run(argc, argv);
+    const LaunchOptions options = GetLaunchOptions(argc, argv);
+
+    std::vector<std::thread> clientThreads;
+    clientThreads.reserve(static_cast<std::size_t>(options.ClientCount));
+
+    for (int i = 0; i < options.ClientCount; ++i)
+    {
+        const int aircraftNumber = options.AircraftStart + i;
+        const std::string aircraftId = BuildAircraftId(aircraftNumber);
+
+        clientThreads.emplace_back([argc, argv, aircraftId]()
+            {
+                std::vector<std::string> args;
+                args.reserve(static_cast<std::size_t>(argc) + 2);
+
+                for (int j = 0; j < argc; ++j)
+                {
+                    args.push_back(argv[j]);
+                }
+
+                args.push_back("--aircraft-id");
+                args.push_back(aircraftId);
+
+                std::vector<char*> cArgs;
+                cArgs.reserve(args.size());
+                for (auto& arg : args)
+                {
+                    cArgs.push_back(arg.data());
+                }
+
+                FleetTelemetry::ClientApp app;
+                app.Run(static_cast<int>(cArgs.size()), cArgs.data());
+            });
+    }
+
+    for (auto& thread : clientThreads)
+    {
+        if (thread.joinable())
+        {
+            thread.join();
+        }
+    }
+
+    return 0;
 }


### PR DESCRIPTION
…nd controlled streaming

- Added multithreaded client execution in main.cpp (multiple clients per run)
- Implemented configurable client count and airplane ID range via CLI (--client-count, --aircraft-start, --aircraft-end)
- Assigned unique, readable airplane IDs (AIRCRAFT-XXX) per client instance
- Added random telemetry file selection per client from data/sample directory
- Ensured one client = one file (no switching during execution)
 - Added configurable delay between reads (--send-interval-ms) to simulate real-time telemetry streaming